### PR TITLE
[TwitterTweetEmbed] Silence error on a corner case scenario.

### DIFF
--- a/src/components/TwitterTweetEmbed.js
+++ b/src/components/TwitterTweetEmbed.js
@@ -24,12 +24,18 @@ export default class TwitterTweetEmbed extends Component {
         return;
       }
 
-      window.twttr.widgets.createTweet(
-        this.props.tweetId,
-        this.refs.embedContainer,
-        this.props.options
-      );
+      if (!this.isMountCanceled) {
+        window.twttr.widgets.createTweet(
+          this.props.tweetId,
+          this.refs.embedContainer,
+          this.props.options
+        );
+      }
     });
+  }
+
+  componentWillUnmount() {
+    this.isMountCanceled = true;
   }
 
   render() {


### PR DESCRIPTION
Do not create the tweet if the component was unmounted before the Twitter library got to load.

Fixes #4.