### PR TITLE
Add onLoaded callback to TweetEmbed

### DIFF
--- a/src/components/TwitterTweetEmbed.js
+++ b/src/components/TwitterTweetEmbed.js
@@ -12,7 +12,11 @@ export default class TwitterTweetEmbed extends Component {
     /**
          * Additional options to pass to twitter widget plugin
          */
-    options: PropTypes.object
+    options: PropTypes.object,
+    /**
+         * Callback to call when the widget is loaded
+         */
+    onLoaded: PropTypes.func
   };
 
   renderWidget() {
@@ -25,7 +29,11 @@ export default class TwitterTweetEmbed extends Component {
         this.props.tweetId,
         this.refs.embedContainer,
         this.props.options
-      )
+      ).then(el => {
+        if (this.props.onLoaded) {
+          this.props.onLoaded(el)
+        }
+      })
     }
   }
 

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -677,6 +677,24 @@ storiesOf('Twitter Tweet Embed', module)
       </div>
     ))
   )
+  .add(
+    'Tweet with custom CSS',
+    withInfo({
+      text: 'Tweet with custom CSS'
+    })(() => (
+      <div className='centerContent'>
+        <div className='selfCenter'>
+          <TwitterTweetEmbed
+            tweetId={'1083592734038929408'}
+            onLoaded={tweetWidgetEl => {
+              const tweetEl = tweetWidgetEl.shadowRoot.querySelector('.EmbeddedTweet')
+              tweetEl.style.border = '5px solid red'
+            }}
+          />
+        </div>
+      </div>
+    ))
+  )
 
 storiesOf('Twitter Moment Share', module)
   .add(


### PR DESCRIPTION
There was no possibility to control `isLoading` status of TweetEmbed. Also, it was complicated to style `#shadowRoot`'s childNodes. That's why I added the `onLoaded` prop, which gives you control over the loaded element. 