### PR TITLE
URL proptype should be lowercase

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-twitter-embed",
-  "version": "2.0.8",
+  "version": "3.0.3",
   "description": "React Twitter Embed Components",
   "author": "Saurabh Nemade",
   "license": "MIT",

--- a/src/components/TwitterTimelineEmbed.js
+++ b/src/components/TwitterTimelineEmbed.js
@@ -9,7 +9,7 @@ export default class TwitterTimelineEmbed extends Component {
     /**
          * This can be either of profile, likes, list, collection, URL, widget
          */
-    sourceType: PropTypes.oneOf(['profile', 'likes', 'list', 'collection', 'URL', 'widget']).isRequired,
+    sourceType: PropTypes.oneOf(['profile', 'likes', 'list', 'collection', 'url', 'widget']).isRequired,
     /**
          * username of twitter handle as String
          */


### PR DESCRIPTION
Got prop type error for uppercase URL in sourceType and noticed it should be lower case for comparisons