### PR TITLE
Made compatible with Preact

### DIFF
--- a/src/components/TwitterDMButton.js
+++ b/src/components/TwitterDMButton.js
@@ -28,6 +28,8 @@ export default class TwitterDMButton extends Component {
     this.state = {
       isLoading: true
     }
+
+    this.embedContainer = React.createRef();
   }
 
   componentDidMount() {
@@ -43,7 +45,7 @@ export default class TwitterDMButton extends Component {
         if (!this.isMountCanceled) {
           window.twttr.widgets.createDMButton(
             this.props.id,
-            this.refs.embedContainer,
+            this.embedContainer.current,
             this.props.options
           ).then((element) => {
             this.setState({
@@ -68,7 +70,7 @@ export default class TwitterDMButton extends Component {
     return (
       <React.Fragment>
         {isLoading && placeholder}
-        <div ref='embedContainer' />
+        <div ref={this.embedContainer} />
       </React.Fragment>
     )
   }

--- a/src/components/TwitterFollowButton.js
+++ b/src/components/TwitterFollowButton.js
@@ -28,6 +28,8 @@ export default class TwitterFollowButton extends Component {
     this.state = {
       isLoading: true
     }
+
+    this.embedContainer = React.createRef();
   }
 
   componentDidMount() {
@@ -43,7 +45,7 @@ export default class TwitterFollowButton extends Component {
         if (!this.isMountCanceled) {
           window.twttr.widgets.createFollowButton(
             this.props.screenName,
-            this.refs.embedContainer,
+            this.embedContainer.current,
             this.props.options
           ).then((element) => {
             this.setState({
@@ -68,7 +70,7 @@ export default class TwitterFollowButton extends Component {
     return (
       <React.Fragment>
         {isLoading && placeholder}
-        <div ref='embedContainer' />
+        <div ref={this.embedContainer} />
       </React.Fragment>
     )
   }

--- a/src/components/TwitterHashtagButton.js
+++ b/src/components/TwitterHashtagButton.js
@@ -28,6 +28,8 @@ export default class TwitterHashtagButton extends Component {
     this.state = {
       isLoading: true
     }
+
+    this.embedContainer = React.createRef();
   }
 
   componentDidMount() {
@@ -43,7 +45,7 @@ export default class TwitterHashtagButton extends Component {
         if (!this.isMountCanceled) {
           window.twttr.widgets.createHashtagButton(
             this.props.tag,
-            this.refs.embedContainer,
+            this.embedContainer.current,
             this.props.options
           ).then((element) => {
             this.setState({
@@ -68,7 +70,7 @@ export default class TwitterHashtagButton extends Component {
     return (
       <React.Fragment>
         {isLoading && placeholder}
-        <div ref='embedContainer' />
+        <div ref={this.embedContainer} />
       </React.Fragment>
     )
   }

--- a/src/components/TwitterMentionButton.js
+++ b/src/components/TwitterMentionButton.js
@@ -28,6 +28,8 @@ export default class TwitterMentionButton extends Component {
     this.state = {
       isLoading: true
     }
+
+    this.embedContainer = React.createRef();
   }
 
   componentDidMount() {
@@ -43,7 +45,7 @@ export default class TwitterMentionButton extends Component {
         if (!this.isMountCanceled) {
           window.twttr.widgets.createMentionButton(
             this.props.screenName,
-            this.refs.embedContainer,
+            this.embedContainer.current,
             this.props.options
           ).then((element) => {
             this.setState({
@@ -68,7 +70,7 @@ export default class TwitterMentionButton extends Component {
     return (
       <React.Fragment>
         {isLoading && placeholder}
-        <div ref='embedContainer' />
+        <div ref={this.embedContainer} />
       </React.Fragment>
     )
   }

--- a/src/components/TwitterMomentShare.js
+++ b/src/components/TwitterMomentShare.js
@@ -28,6 +28,8 @@ export default class TwitterMomentShare extends Component {
     this.state = {
       isLoading: true
     }
+
+    this.shareMoment = React.createRef();
   }
 
   componentDidMount() {
@@ -43,7 +45,7 @@ export default class TwitterMomentShare extends Component {
         if (!this.isMountCanceled) {
           window.twttr.widgets.createMoment(
             this.props.momentId,
-            this.refs.shareMoment,
+            this.shareMoment.current,
             this.props.options
           ).then((element) => {
             this.setState({
@@ -68,7 +70,7 @@ export default class TwitterMomentShare extends Component {
     return (
       <React.Fragment>
         {isLoading && placeholder}
-        <div ref='shareMoment' />
+        <div ref={this.shareMoment} />
       </React.Fragment>
     )
   }

--- a/src/components/TwitterOnAirButton.js
+++ b/src/components/TwitterOnAirButton.js
@@ -28,6 +28,8 @@ export default class TwitterOnAirButton extends Component {
     this.state = {
       isLoading: true
     }
+
+    this.embedContainer = React.createRef();
   }
 
   componentDidMount() {
@@ -43,7 +45,7 @@ export default class TwitterOnAirButton extends Component {
         if (!this.isMountCanceled) {
           window.twttr.widgets.createPeriscopeOnAirButton(
             this.props.username,
-            this.refs.embedContainer,
+            this.embedContainer.current,
             this.props.options
           ).then((element) => {
             this.setState({
@@ -68,7 +70,7 @@ export default class TwitterOnAirButton extends Component {
     return (
       <React.Fragment>
         {isLoading && placeholder}
-        <div ref='embedContainer' />
+        <div ref={this.embedContainer} />
       </React.Fragment>
     )
   }

--- a/src/components/TwitterShareButton.js
+++ b/src/components/TwitterShareButton.js
@@ -29,6 +29,8 @@ export default class TwitterShareButton extends Component {
     this.state = {
       isLoading: true
     }
+
+    this.embedContainer = React.createRef();
   }
 
   componentDidMount() {
@@ -44,7 +46,7 @@ export default class TwitterShareButton extends Component {
         if (!this.isMountCanceled) {
           window.twttr.widgets.createShareButton(
             this.props.url,
-            this.refs.embedContainer,
+            this.embedContainer.current,
             this.props.options
           ).then((element) => {
             this.setState({
@@ -69,7 +71,7 @@ export default class TwitterShareButton extends Component {
     return (
       <React.Fragment>
         {isLoading && placeholder}
-        <div ref='embedContainer' />
+        <div ref={this.embedContainer} />
       </React.Fragment>
     )
   }

--- a/src/components/TwitterTimelineEmbed.js
+++ b/src/components/TwitterTimelineEmbed.js
@@ -100,6 +100,8 @@ export default class TwitterTimelineEmbed extends Component {
     this.state = {
       isLoading: true
     }
+
+    this.embedContainer = React.createRef();
   }
 
   buildChromeOptions(options) {
@@ -119,7 +121,7 @@ export default class TwitterTimelineEmbed extends Component {
 
   buildOptions() {
     let options = Object.assign({}, this.props.options)
-    if (this.props.autoHeight) { options.height = this.refs.embedContainer.parentNode.offsetHeight }
+    if (this.props.autoHeight) { options.height = this.embedContainer.current.parentNode.offsetHeight }
 
     options = Object.assign({}, options, {
       theme: this.props.theme,
@@ -144,7 +146,7 @@ export default class TwitterTimelineEmbed extends Component {
           id: this.props.id || this.props.widgetId,
           url: this.props.url
         },
-        this.refs.embedContainer,
+        this.embedContainer.current,
         options
       ).then((element) => {
         this.setState({
@@ -184,7 +186,7 @@ export default class TwitterTimelineEmbed extends Component {
     return (
       <React.Fragment>
         {isLoading && placeholder}
-        <div ref='embedContainer' />
+        <div ref={this.embedContainer} />
       </React.Fragment>
     )
   }

--- a/src/components/TwitterTweetEmbed.js
+++ b/src/components/TwitterTweetEmbed.js
@@ -28,6 +28,8 @@ export default class TwitterTweetEmbed extends Component {
     this.state = {
       isLoading: true
     }
+
+    this.embedContainer = React.createRef();
   }
 
   renderWidget() {
@@ -39,7 +41,7 @@ export default class TwitterTweetEmbed extends Component {
     if (!this.isMountCanceled) {
       window.twttr.widgets.createTweet(
         this.props.tweetId,
-        this.refs.embedContainer,
+        this.embedContainer.current,
         this.props.options
       ).then((element) => {
         this.setState({
@@ -71,7 +73,7 @@ export default class TwitterTweetEmbed extends Component {
     return (
       <React.Fragment>
         {isLoading && placeholder}
-        <div ref='embedContainer' />
+        <div ref={this.embedContainer} />
       </React.Fragment>
     )
   }

--- a/src/components/TwitterVideoEmbed.js
+++ b/src/components/TwitterVideoEmbed.js
@@ -24,6 +24,8 @@ export default class TwitterVideoEmbed extends Component {
     this.state = {
       isLoading: true
     }
+
+    this.embedContainer = React.createRef();
   }
 
   componentDidMount() {
@@ -38,7 +40,7 @@ export default class TwitterVideoEmbed extends Component {
         if (!this.isMountCanceled) {
           window.twttr.widgets.createVideo(
             this.props.id,
-            this.refs.embedContainer
+            this.embedContainer.current
           ).then((element) => {
             this.setState({
               isLoading: false
@@ -62,7 +64,7 @@ export default class TwitterVideoEmbed extends Component {
     return (
       <React.Fragment>
         {isLoading && placeholder}
-        <div ref='embedContainer' />
+        <div ref={this.embedContainer} />
       </React.Fragment>
     )
   }


### PR DESCRIPTION
This makes the library compatible with Preact but also removes the deprecated way of using refs in React as explained in the [documention](https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs).

This should be part of a new major release.