### PR TITLE
Fix bug render two div that present center placeholder

### DIFF
--- a/src/components/TwitterVideoEmbed.tsx
+++ b/src/components/TwitterVideoEmbed.tsx
@@ -63,8 +63,7 @@ const TwitterVideoEmbed = (props: TwitterVideoEmbedProps): any => {
 
   return (
     <React.Fragment>
-      {loading && <React.Fragment>{props.placeholder}</React.Fragment>}
-      <div ref={ref} />
+      {loading ? props.placeholder : <div ref={ref} />}
     </React.Fragment>
   );
 };


### PR DESCRIPTION
If you try center the React node passed to placeholder prop, the loader is not 100% centered because there is a void div that use the other half of the psace to center.

Bug:
![image](https://github.com/saurabhnemade/react-twitter-embed/assets/7991036/c19771e8-1cd6-4114-ba8e-523fc42c1ee5)



**PR Checklist**

- [x] Add feature name in the title
- [x] Set the context in the description
- [ ] Set the appropriate label
- [ ] Add tests
- [x] Relevant screenshots
- [x] Fixed a bug? Add it as a test
- [ ] is a breaking change?
